### PR TITLE
metadata: Mark GNOME 44 as supported

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
     "name": "Power Profile Switcher",
     "description": "Automatically switch between power profiles based on power supply and percentage.",
     "version": 3,
-    "shell-version": ["42", "43"],
+    "shell-version": ["42", "43", "44"],
     "url": "https://github.com/eliapasquali/power-profile-switcher"
 }


### PR DESCRIPTION
I've tested this on GNOME 44 and it runs and appears to work.